### PR TITLE
Fixed 404 of `wiki` link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 [![Build Status](https://travis-ci.com/verizon-media-2019-ais3/identity-service.svg?branch=master)](https://travis-ci.com/verizon-media-2019-ais3/identity-service)
 
-See [Wiki](./wiki) for how the details.
+See [Wiki](https://github.com/verizon-media-2019-ais3/identity-service/wiki) for the details.


### PR DESCRIPTION
`./wiki` will be resolved as file system path, not web URL relative path, hence resulting in a 404.