### PR TITLE
Rollback Jersey version because of compatibility issue.

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -305,7 +305,7 @@
         <swagger-core-version>1.5.22</swagger-core-version>
         <beanvalidation-version>1.1.0.Final</beanvalidation-version>
         <jetty-version>9.2.9.v20150224</jetty-version>
-        <jersey2-version>2.28</jersey2-version>
+        <jersey2-version>2.22.2</jersey2-version>
         <jackson-version>2.9.9</jackson-version>
         <junit-version>4.12</junit-version>
         <jmockit-version>1.46</jmockit-version>


### PR DESCRIPTION
New version will make jetty unable to start
```
[WARNING] Failed startup of context o.e.j.m.p.JettyWebAppContext@7db679{/,file:/root/code/src/main/webapp/,STARTING}{file:/root/code/src/main/webapp/}
org.eclipse.jetty.util.MultiException: Multiple exceptions
    at org.eclipse.jetty.annotations.AnnotationConfiguration.scanForAnnotations (AnnotationConfiguration.java:536)
    at org.eclipse.jetty.annotations.AnnotationConfiguration.configure (AnnotationConfiguration.java:447)
    at org.eclipse.jetty.webapp.WebAppContext.configure (WebAppContext.java:479)
    at org.eclipse.jetty.webapp.WebAppContext.startContext (WebAppContext.java:1337)
    at org.eclipse.jetty.server.handler.ContextHandler.doStart (ContextHandler.java:741)

```