### PR TITLE
Increase the wait of time for jetty start.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,8 @@ script:
   - docker-compose exec identity-frontend go build -o server
   - docker-compose exec -d identity-backend mvn jetty:run
   - docker-compose exec -d identity-frontend ./server
-  - sleep 30
+  - sleep 60
   - echo Run functional test
   - docker-compose exec identity-functest mvn clean
   - docker-compose exec identity-functest mvn test -Dcucumber.options="--tags @registerTest"
   - docker-compose exec identity-functest mvn test -Dcucumber.options="--tags @loginTest,@updateTest"
-  - sleep 10


### PR DESCRIPTION
Increase the wait of time for jetty start to see if it can solve the failure of TravisCI build. (I cannot reproduce it locally)